### PR TITLE
Use checkout@v4

### DIFF
--- a/.github/workflows/add-link.yaml
+++ b/.github/workflows/add-link.yaml
@@ -16,7 +16,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Process new link request
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Updated add-link.yaml to use actions/checkout@v4 as v3 is deprecated.