### PR TITLE
Fix handle of Immo Landwerth/terrajobst

### DIFF
--- a/website/config/terrajobst.bsky.social.json
+++ b/website/config/terrajobst.bsky.social.json
@@ -1,7 +1,7 @@
 {
   "title": "Immo Landwerth",
   "category": "dotnet",
-  "bluesky": "terrajobst.bsky.social",
+  "bluesky": "terrajobst.net",
   "twitter": "terrajobst",
   "type": "microsoft",
   "did": "did:plc:dyidtvrczrdyracol7td4qtf"


### PR DESCRIPTION
I recently changed my handle to the domain; looks like Bluesky doesn't forward those. Sadness.