### PR TITLE
pdebruin.bsky to pdebruin.org

### DIFF
--- a/website/config/pdebruin.org.json
+++ b/website/config/pdebruin.org.json
@@ -1,7 +1,7 @@
 {
   "title": "Pieter de Bruin ",
   "category": null,
-  "bluesky": "pdebruin.bsky.social",
+  "bluesky": "pdebruin.org",
   "twitter": "pieter_de_bruin",
   "type": "microsoft",
   "did": "did:plc:k252lurdbddlpsqn32s2tztn"


### PR DESCRIPTION
Renamed the json file and the bluesky value to the new domain name. Hope this is correct. 