### PR TITLE
Add GitHub Actions Workflow to validate JSON files in website\config

### DIFF
--- a/.github/workflows/validate-json-files.yaml
+++ b/.github/workflows/validate-json-files.yaml
@@ -14,7 +14,7 @@ jobs:
           $jsonFilesInConfigFolder = Get-ChildItem -Path website\config -Name
           foreach ($file in $jsonFilesInConfigFolder) {
             if ($file.EndsWith(".json")) {
-              $isValidJson = Get-Content $file -Raw | Test-Json
+              $isValidJson = Get-Content website\config\$file -Raw | Test-Json
               if (!$isValidJson) {
                 throw "File $file contains invalid json content"
                 Exit 1

--- a/.github/workflows/validate-json-files.yaml
+++ b/.github/workflows/validate-json-files.yaml
@@ -14,7 +14,7 @@ jobs:
           $jsonFilesInConfigFolder = Get-ChildItem -Path website\config -Name
           foreach ($file in $jsonFilesInConfigFolder) {
             if ($file.EndsWith(".json")) {
-              $isValidJson = Get-Content website\config\$file -Raw | Test-Json
+              $isValidJson = Get-Content website\config\$file -Raw | Test-Json -ErrorAction Continue
               if (!$isValidJson) {
                 throw "File $file contains invalid json content"
                 Exit 1

--- a/.github/workflows/validate-json-files.yaml
+++ b/.github/workflows/validate-json-files.yaml
@@ -8,12 +8,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - id: files
-        uses: jitterbit/get-changed-files@v1
-      - name: Execute Test-Json on all changed JSON files
+      - name: Execute Test-Json on all JSON files in website/config
         shell: pwsh
         run: |
-          foreach ($file in ${{ steps.files.outputs.all }} -split " ") {
+          $jsonFilesInConfigFolder = Get-ChildItem -Path website\config -Name
+          foreach ($file in $jsonFilesInConfigFolder) {
             if ($file.EndsWith(".json")) {
               $isValidJson = Get-Content $file -Raw | Test-Json
               if (!$isValidJson) {

--- a/.github/workflows/validate-json-files.yaml
+++ b/.github/workflows/validate-json-files.yaml
@@ -1,0 +1,23 @@
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  validate_json_files:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - id: files
+        uses: jitterbit/get-changed-files@v1
+      - name: Execute Test-Json on all changed JSON files
+        shell: pwsh
+        run: |
+          foreach ($file in ${{ steps.files.outputs.all }}) {
+            if ($file.EndsWith(".json")) {
+              $isValidJson = Get-Content $file -Raw | Test-Json
+              if (!$isValidJson) {
+                throw "File $file contains invalid json content"
+              }
+            }
+          }

--- a/.github/workflows/validate-json-files.yaml
+++ b/.github/workflows/validate-json-files.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Execute Test-Json on all changed JSON files
         shell: pwsh
         run: |
-          foreach ($file in ${{ steps.files.outputs.all }}) {
+          foreach ($file in ${{ steps.files.outputs.all }} -split " ") {
             if ($file.EndsWith(".json")) {
               $isValidJson = Get-Content $file -Raw | Test-Json
               if (!$isValidJson) {

--- a/.github/workflows/validate-json-files.yaml
+++ b/.github/workflows/validate-json-files.yaml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
 
 jobs:
   validate_json_files:

--- a/.github/workflows/validate-json-files.yaml
+++ b/.github/workflows/validate-json-files.yaml
@@ -18,6 +18,7 @@ jobs:
               $isValidJson = Get-Content $file -Raw | Test-Json
               if (!$isValidJson) {
                 throw "File $file contains invalid json content"
+                Exit 1
               }
             }
           }

--- a/website/config/rufer7.bsky.social.json
+++ b/website/config/rufer7.bsky.social.json
@@ -1,5 +1,5 @@
 {
-  "title": "Marc Rufer",
+  "title": "Marc Rufer,
   "category": "dev",
   "bluesky": "rufer.be",
   "twitter": "",

--- a/website/config/rufer7.bsky.social.json
+++ b/website/config/rufer7.bsky.social.json
@@ -1,5 +1,5 @@
 {
-  "title": "Marc Rufer,
+  "title": "Marc Rufer",
   "category": "dev",
   "bluesky": "rufer.be",
   "twitter": "",


### PR DESCRIPTION
Hi @merill

This is just a suggestion for a GitHub Actions Workflow that does the following when opening, editing or synchronizing (add commits) a pull request.

- Checks out the repository content
- Gets all file names of files in `website\config`
- Executes `Test-Json` PowerShell command against all files that end with `.json`

If one of the JSON files does not contain valid JSON content the output looks as shown [here](https://github.com/rufer7/bluesky/actions/runs/12141913485/job/33855115461).

This GitHub Actions Workflow could be configured as required check, so that PRs can only be merged, if the workflow succeeds.

Feel free to either take this or just ignore and discard.